### PR TITLE
Parallelize S3 deploy uploads and preserve redirect keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,21 +64,10 @@ jobs:
         run: |
           aws s3 sync public/ "s3://${S3_BUCKET}" --delete \
             --exclude "_redirects" --exclude "_headers" \
+            --exclude "atom.xml" --exclude "feed/index.html" \
             --exclude "*.js" --exclude "*.css" \
             --cli-connect-timeout 60 --cli-read-timeout 300 &
           sync_pid=$!
-
-          aws s3 cp public/ "s3://${S3_BUCKET}" --recursive \
-            --exclude "*" --include "*.js" \
-            --cache-control "public, max-age=86400" \
-            --cli-connect-timeout 60 --cli-read-timeout 300 &
-          js_pid=$!
-
-          aws s3 cp public/ "s3://${S3_BUCKET}" --recursive \
-            --exclude "*" --include "*.css" \
-            --cache-control "public, max-age=86400" \
-            --cli-connect-timeout 60 --cli-read-timeout 300 &
-          css_pid=$!
 
           aws s3api put-object --bucket "${S3_BUCKET}" --key "atom.xml" \
             --website-redirect-location "/feed.atom" &
@@ -88,11 +77,23 @@ jobs:
             --website-redirect-location "/feed.atom" &
           feed_redirect_pid=$!
 
+          aws s3 sync public/ "s3://${S3_BUCKET}" --delete \
+            --exclude "*" --include "*.js" \
+            --cache-control "public, max-age=86400" \
+            --cli-connect-timeout 60 --cli-read-timeout 300 &
+          js_pid=$!
+
+          aws s3 sync public/ "s3://${S3_BUCKET}" --delete \
+            --exclude "*" --include "*.css" \
+            --cache-control "public, max-age=86400" \
+            --cli-connect-timeout 60 --cli-read-timeout 300 &
+          css_pid=$!
+
           wait "$sync_pid"
-          wait "$js_pid"
-          wait "$css_pid"
           wait "$atom_redirect_pid"
           wait "$feed_redirect_pid"
+          wait "$js_pid"
+          wait "$css_pid"
 
   invalidate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Run the main site sync, JS sync, CSS sync, and feed redirect writes in parallel to reduce deploy time.
- Exclude `atom.xml` and `feed/index.html` from the main sync so redirect objects are not deleted mid-deploy.
- Keep JS and CSS on separate sync paths so they still get their cache-control metadata while also deleting stale assets.

## Testing
- YAML syntax validated locally.
- Reviewed the updated workflow logic to confirm the parallel jobs do not race on the redirect objects.